### PR TITLE
feat: Initial Sancho app scaffolding and branding

### DIFF
--- a/sancho.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/sancho.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/sancho.xcodeproj/project.xcworkspace/xcuserdata/arminghajarjazi.xcuserdatad/WorkspaceSettings.xcsettings
+++ b/sancho.xcodeproj/project.xcworkspace/xcuserdata/arminghajarjazi.xcuserdatad/WorkspaceSettings.xcsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildLocationStyle</key>
+	<string>UseAppPreferences</string>
+	<key>CustomBuildLocationType</key>
+	<string>RelativeToDerivedData</string>
+	<key>DerivedDataLocationStyle</key>
+	<string>Default</string>
+	<key>ShowSharedSchemesAutomaticallyEnabled</key>
+	<true/>
+</dict>
+</plist>

--- a/sancho/AuthenticationView.swift
+++ b/sancho/AuthenticationView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct AuthenticationView: View {
+    @State private var email = ""
+    @State private var password = ""
+
+    // This binding will be passed from sanchoApp to update the authentication state
+    @Binding var isAuthenticated: Bool
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Welcome to Sancho!")
+                .font(.largeTitle)
+                .padding(.bottom, 40)
+
+            TextField("Email", text: $email)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .keyboardType(.emailAddress)
+                .autocapitalization(.none)
+
+            SecureField("Password", text: $password)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+            Button("Login") {
+                // Action for login (placeholder)
+                print("Login button tapped")
+            }
+            .padding()
+            .buttonStyle(.borderedProminent)
+
+            Button("Sign Up") {
+                // Action for sign up (placeholder)
+                print("Sign Up button tapped")
+            }
+            .buttonStyle(.bordered)
+
+            // Temporary button to simulate successful login
+            Button("Simulate Login") {
+                isAuthenticated = true
+            }
+            .padding(.top, 30)
+            .foregroundColor(.gray)
+        }
+        .padding()
+    }
+}
+
+// For previewing, we need to provide a constant binding
+#Preview {
+    AuthenticationView(isAuthenticated: .constant(false))
+}

--- a/sancho/ContentView.swift
+++ b/sancho/ContentView.swift
@@ -6,56 +6,33 @@
 //
 
 import SwiftUI
-import SwiftData
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
-
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
-                    }
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house.fill")
                 }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
-                }
-            }
-        } detail: {
-            Text("Select an item")
-        }
-    }
 
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
+            LearnView()
+                .tabItem {
+                    Label("Learn", systemImage: "book.fill")
+                }
 
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
-            }
+            PracticeView()
+                .tabItem {
+                    Label("Practice", systemImage: "figure.walk")
+                }
+
+            ProfileView()
+                .tabItem {
+                    Label("Profile", systemImage: "person.fill")
+                }
         }
     }
 }
 
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
 }

--- a/sancho/HomeView.swift
+++ b/sancho/HomeView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        NavigationView {
+            VStack {
+                Spacer()
+                Text("¡Hola! I'm Sancho - Your AI Spanish learning companion")
+                    .multilineTextAlignment(.center)
+                    .padding() // Added padding for better appearance
+                Spacer()
+            }
+            .navigationTitle("Sancho's Home")
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/sancho/LearnView.swift
+++ b/sancho/LearnView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct LearnView: View {
+    var body: some View {
+        NavigationView {
+            Text("Learn Screen")
+                .navigationTitle("Learn with Sancho")
+        }
+    }
+}
+
+#Preview {
+    LearnView()
+}

--- a/sancho/LearningSession.swift
+++ b/sancho/LearningSession.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+@Model
+final class LearningSession {
+    var startTime: Date
+    var endTime: Date
+    var topic: String
+    var wordsLearned: [String] // SwiftData can handle arrays of simple types
+
+    init(startTime: Date = Date(), endTime: Date = Date(), topic: String = "", wordsLearned: [String] = []) {
+        self.startTime = startTime
+        self.endTime = endTime
+        self.topic = topic
+        self.wordsLearned = wordsLearned
+    }
+}

--- a/sancho/PracticeView.swift
+++ b/sancho/PracticeView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct PracticeView: View {
+    var body: some View {
+        NavigationView {
+            Text("Practice Screen")
+                .navigationTitle("Practice with Sancho")
+        }
+    }
+}
+
+#Preview {
+    PracticeView()
+}

--- a/sancho/ProfileView.swift
+++ b/sancho/ProfileView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        NavigationView {
+            Text("Profile Screen")
+                .navigationTitle("Your Sancho Profile")
+        }
+    }
+}
+
+#Preview {
+    ProfileView()
+}

--- a/sancho/UserProgress.swift
+++ b/sancho/UserProgress.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftData
+
+@Model
+final class UserProgress {
+    var currentLevel: Int
+    var totalWordsLearned: Int
+
+    // SwiftData can handle relationships.
+    // If this is a one-to-many relationship, it might require @Relationship.
+    // For now, a simple array should work for embedding or a simple relation.
+    // Let's assume for now these are owned by UserProgress.
+    // If they need to be independent entities with inverse relationships,
+    // @Relationship would be needed.
+    @Relationship(deleteRule: .cascade) // If UserProgress is deleted, associated LearningSessions are also deleted.
+    var completedSessions: [LearningSession]? // Use optional if it can be empty initially or for flexibility
+
+    init(currentLevel: Int = 1, totalWordsLearned: Int = 0, completedSessions: [LearningSession]? = []) {
+        self.currentLevel = currentLevel
+        self.totalWordsLearned = totalWordsLearned
+        self.completedSessions = completedSessions
+    }
+}

--- a/sancho/sanchoApp.swift
+++ b/sancho/sanchoApp.swift
@@ -10,9 +10,12 @@ import SwiftData
 
 @main
 struct sanchoApp: App {
+    @State private var isAuthenticated = false
+
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
-            Item.self,
+            LearningSession.self,
+            UserProgress.self,
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
@@ -25,7 +28,11 @@ struct sanchoApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            if isAuthenticated {
+                ContentView()
+            } else {
+                AuthenticationView(isAuthenticated: $isAuthenticated)
+            }
         }
         .modelContainer(sharedModelContainer)
     }

--- a/sanchoTests/sanchoTests.swift
+++ b/sanchoTests/sanchoTests.swift
@@ -6,12 +6,97 @@
 //
 
 import Testing
-@testable import sancho
+import SwiftData
+@testable import sancho // Ensure your main app target is importable
 
-struct sanchoTests {
+@Suite struct ModelTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    var modelContext: ModelContext
+
+    init() {
+        // Create an in-memory model container for testing
+        let schema = Schema([LearningSession.self, UserProgress.self])
+        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        do {
+            let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+            modelContext = ModelContext(container)
+        } catch {
+            fatalError("Failed to create in-memory model container: \(error)")
+        }
     }
 
+    @Test func testLearningSessionInitialization() {
+        let startTime = Date()
+        let endTime = startTime.addingTimeInterval(3600) // 1 hour later
+        let topic = "Colors"
+        let words = ["rojo", "azul", "verde"]
+
+        let session = LearningSession(startTime: startTime, endTime: endTime, topic: topic, wordsLearned: words)
+
+        #expect(session.startTime == startTime)
+        #expect(session.endTime == endTime)
+        #expect(session.topic == topic)
+        #expect(session.wordsLearned == words)
+        #expect(session.wordsLearned.count == 3)
+    }
+
+    @Test func testLearningSessionDefaultInitialization() {
+        let session = LearningSession()
+        // Check that default values are not nil or empty if they shouldn't be,
+        // or are empty/default if that's the expectation.
+        // For Date, it will be approximately Date(), so direct comparison is tricky.
+        // Check if it's recent enough.
+        #expect(abs(session.startTime.timeIntervalSinceNow) < 5) // Within 5 seconds
+        #expect(abs(session.endTime.timeIntervalSinceNow) < 5)   // Within 5 seconds
+        #expect(session.topic == "")
+        #expect(session.wordsLearned.isEmpty)
+    }
+
+    @Test func testUserProgressInitialization() {
+        let progress = UserProgress(currentLevel: 2, totalWordsLearned: 50, completedSessions: [])
+
+        #expect(progress.currentLevel == 2)
+        #expect(progress.totalWordsLearned == 50)
+        #expect(progress.completedSessions != nil)
+        #expect(progress.completedSessions?.isEmpty == true)
+    }
+
+    @Test func testUserProgressDefaultInitialization() {
+        let progress = UserProgress()
+        #expect(progress.currentLevel == 1)
+        #expect(progress.totalWordsLearned == 0)
+        #expect(progress.completedSessions != nil)
+        #expect(progress.completedSessions?.isEmpty == true)
+    }
+
+    @Test func testUserProgressAddingSession() throws {
+        let progress = UserProgress()
+        modelContext.insert(progress) // Insert into context to manage relationship
+
+        let session1 = LearningSession(topic: "Greetings", wordsLearned: ["hola", "adiós"])
+        modelContext.insert(session1) // Also insert session if it's an independent entity
+
+        // If completedSessions is nil (due to optional init), initialize it
+        if progress.completedSessions == nil {
+            progress.completedSessions = []
+        }
+        progress.completedSessions?.append(session1)
+
+        #expect(progress.completedSessions?.count == 1)
+        #expect(progress.completedSessions?.first?.topic == "Greetings")
+
+        let session2 = LearningSession(topic: "Numbers", wordsLearned: ["uno", "dos"])
+        modelContext.insert(session2)
+        progress.completedSessions?.append(session2)
+
+        #expect(progress.completedSessions?.count == 2)
+        #expect(progress.completedSessions?.last?.topic == "Numbers")
+
+        // Verify persistence if desired (fetch request)
+        // This might be more of an integration test for SwiftData itself
+        let descriptor = FetchDescriptor<UserProgress>()
+        let fetchedProgressItems = try modelContext.fetch(descriptor)
+        let fetchedProgress = fetchedProgressItems.first
+        #expect(fetchedProgress?.completedSessions?.count == 2)
+    }
 }

--- a/sanchoTests/sanchoTests.swift
+++ b/sanchoTests/sanchoTests.swift
@@ -8,6 +8,7 @@
 import Testing
 import SwiftData
 @testable import sancho // Ensure your main app target is importable
+import Foundation
 
 @Suite struct ModelTests {
 

--- a/sanchoUITests/sanchoUITests.swift
+++ b/sanchoUITests/sanchoUITests.swift
@@ -9,33 +9,72 @@ import XCTest
 
 final class sanchoUITests: XCTestCase {
 
+    var app: XCUIApplication!
+
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        app = XCUIApplication()
+        // It's good practice to reset launch arguments for each test if needed,
+        // or set them if your app behaves differently during UI tests.
+        // app.launchArguments.append("--uitesting")
+        app.launch()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        app = nil
     }
 
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
+    func testWelcomeMessageIsDisplayedAfterLogin() throws {
+        // On AuthenticationView
+        let simulateLoginButton = app.buttons["Simulate Login"]
+        XCTAssertTrue(simulateLoginButton.waitForExistence(timeout: 5), "The 'Simulate Login' button should exist on the AuthenticationView.")
+        simulateLoginButton.tap()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Now on HomeView (within ContentView's TabView)
+        // Check for the navigation title of HomeView first.
+        let homeNavigationTitle = app.navigationBars["Sancho's Home"].staticTexts["Sancho's Home"]
+        XCTAssertTrue(homeNavigationTitle.waitForExistence(timeout: 5), "The Home screen with navigation title 'Sancho's Home' should be displayed after login.")
+
+        // Then check for the welcome message itself.
+        let welcomeMessage = app.staticTexts["¡Hola! I'm Sancho - Your AI Spanish learning companion"]
+        XCTAssertTrue(welcomeMessage.waitForExistence(timeout: 5), "The welcome message should be displayed on the Home screen.")
     }
 
     @MainActor
-    func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
-        measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
-        }
+    func testTabNavigationFlow() throws {
+        // 1. Login
+        let simulateLoginButton = app.buttons["Simulate Login"]
+        XCTAssertTrue(simulateLoginButton.waitForExistence(timeout: 5), "The 'Simulate Login' button must exist to start the navigation test.")
+        simulateLoginButton.tap()
+
+        // 2. Verify Home tab is initially selected and its title is correct
+        // The navigationBar identifier is its title.
+        let homeNavBar = app.navigationBars["Sancho's Home"]
+        XCTAssertTrue(homeNavBar.waitForExistence(timeout: 5), "The Home screen (identified by navigation bar 'Sancho's Home') should be visible initially.")
+
+        // 3. Navigate to Learn tab and verify its title
+        let learnTabButton = app.tabBars.buttons["Learn"] // Assumes tab bar buttons are identified by their labels
+        XCTAssertTrue(learnTabButton.exists, "The 'Learn' tab bar button should exist.")
+        learnTabButton.tap()
+
+        let learnNavBar = app.navigationBars["Learn with Sancho"]
+        XCTAssertTrue(learnNavBar.waitForExistence(timeout: 5), "The Learn screen (identified by navigation bar 'Learn with Sancho') should be displayed after tapping the 'Learn' tab.")
+
+        // 4. Navigate to Practice tab and verify its title
+        let practiceTabButton = app.tabBars.buttons["Practice"]
+        XCTAssertTrue(practiceTabButton.exists, "The 'Practice' tab bar button should exist.")
+        practiceTabButton.tap()
+
+        let practiceNavBar = app.navigationBars["Practice with Sancho"]
+        XCTAssertTrue(practiceNavBar.waitForExistence(timeout: 5), "The Practice screen (identified by navigation bar 'Practice with Sancho') should be displayed after tapping the 'Practice' tab.")
+
+        // 5. Navigate to Profile tab and verify its title
+        let profileTabButton = app.tabBars.buttons["Profile"]
+        XCTAssertTrue(profileTabButton.exists, "The 'Profile' tab bar button should exist.")
+        profileTabButton.tap()
+
+        let profileNavBar = app.navigationBars["Your Sancho Profile"]
+        XCTAssertTrue(profileNavBar.waitForExistence(timeout: 5), "The Profile screen (identified by navigation bar 'Your Sancho Profile') should be displayed after tapping the 'Profile' tab.")
     }
 }


### PR DESCRIPTION
This commit introduces the initial structure and branding for the Sancho iOS app.

Key changes include:
- Updated ContentView to display a welcome message: "¡Hola! I'm Sancho - Your AI Spanish learning companion" on the Home screen.
- Implemented a tab-based navigation system with placeholder views for Home, Learn, Practice, and Profile sections.
- Incorporated Sancho's persona in navigation titles (e.g., "Sancho's Home", "Learn with Sancho").
- Set up a placeholder authentication flow with a basic login/signup UI. Actual authentication logic is not yet implemented.
- Defined SwiftData models for `LearningSession` and `UserProgress` to store learning activity and progress data.
- Added unit tests for the `LearningSession` and `UserProgress` data models.
- Added UI tests to verify the display of the welcome message and the functionality of the tab navigation.

These changes establish the foundational elements of the Sancho app, aligning with your story's goal of creating a personalized AI companion feel from the outset.