### PR TITLE
feat: Update LearnView with navigation to PracticeView

### DIFF
--- a/sancho/LearnView.swift
+++ b/sancho/LearnView.swift
@@ -3,12 +3,21 @@ import SwiftUI
 struct LearnView: View {
     var body: some View {
         NavigationView {
-            Text("Learn Screen")
-                .navigationTitle("Learn with Sancho")
+            VStack(spacing: 30) {
+                Spacer()
+
+                Text("Ready to practice your Spanish?")
+                    .font(.title2)
+                    .multilineTextAlignment(.center)
+
+                NavigationLink(destination: PracticeView()) {
+                    SanchoButton(title: "Start Speaking Practice") { }
+                }
+
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Learn with Sancho")
         }
     }
-}
-
-#Preview {
-    LearnView()
 }


### PR DESCRIPTION
Replaced placeholder text in LearnView with an encouraging message and a 'Start Speaking Practice' button. Tapping the button now navigates you to PracticeView.

This change implements the first phase of the Voice Practice feature, establishing the entry point for the voice practice flow. PracticeView remains a placeholder and will be updated in a subsequent phase.