### PR TITLE
feat: Implement conversation screen skeleton

### DIFF
--- a/sancho/PracticeView.swift
+++ b/sancho/PracticeView.swift
@@ -3,8 +3,22 @@ import SwiftUI
 struct PracticeView: View {
     var body: some View {
         NavigationView {
-            Text("Practice Screen")
-                .navigationTitle("Practice with Sancho")
+            VStack {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        SanchoBubble(text: "¡Hola! Soy Sancho. Let's practice!", isCurrentUser: false)
+                        SanchoBubble(text: "Hola Sancho!", isCurrentUser: true)
+                    }
+                    .padding()
+                }
+
+                Spacer()
+
+                SanchoMicButton()
+                    .frame(width: 80, height: 80) // Explicitly set frame as in issue example
+                    .padding(.bottom, 20)
+            }
+            .navigationTitle("Sancho Chat")
         }
     }
 }


### PR DESCRIPTION
Builds the basic UI for the conversation screen in PracticeView as per Phase 2 requirements.

Key changes:
- Replaced placeholder content in PracticeView with a chat-like interface.
- Displays Sancho's greeting bubble (left-aligned, gray background).
- Displays a placeholder user reply bubble (right-aligned, primary color background).
- Adds the SanchoMicButton at the bottom center in its default (idle) visual state (teal, no pulse).
- Sets the navigation title to "Sancho Chat".

The implementation uses existing SanchoUI components (SanchoBubble, SanchoMicButton, SanchoTheme) and lays them out using VStack and ScrollView. This provides the foundational UI for future speech interaction functionality.